### PR TITLE
Changed logic for wrap when index is greater than length

### DIFF
--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -19,7 +19,7 @@ export class Slider extends React.PureComponent<SliderProps> {
     get maxScrollLeft() {
         const { slides, slidesToShow } = this.props;
 
-        return (slides.length * this.slideWidth) - (slidesToShow * this.slideWidth);
+        return (slides.length - slidesToShow) * this.slideWidth;
     }
 
     get scrollLeft() {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,2 +1,2 @@
-export const wrap = (index, length) => (length + (index % length)) % length;
+export const wrap = (index, length) => index > length ? 0 : index;
 export const clamp = (index, min, max) => Math.max(min, Math.min(index, max));


### PR DESCRIPTION
Changed the logic for the wrap function in Util so that is returns to 0 when index is increased over the number of slides.